### PR TITLE
feat: add cudo compute to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ See a full list on [Vue Telescope](https://www.vuetelescope.com/explore?framewor
 - [Lineup11.net](https://www.lineup11.net/) - Lineup11: Football lineup builder application to help users build football formations and share. Built with Nuxt.js.
 - [Faker.js UI](https://fakerjsui.com) - Faker.js UI. Use Faker.js UI to easily generate fake (but realistic) data for testing and development using Faker.js.
 - [Hippocrades](https://hippocrades.com/) - Enterprise-Grade Health Solutions Made Affordable
-- [Cudo Compute](https://cudocompute.com/) - Democratized cloud platform built with nuxt3, @nuxt/content and tailwind
+- [Cudo Compute](https://www.cudocompute.com/) - Democratized cloud platform built with nuxt3, @nuxt/content and tailwind
   
 > Please don't hesitate to make a PR if you have more resources to share.
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,8 @@ See a full list on [Vue Telescope](https://www.vuetelescope.com/explore?framewor
 - [Lineup11.net](https://www.lineup11.net/) - Lineup11: Football lineup builder application to help users build football formations and share. Built with Nuxt.js.
 - [Faker.js UI](https://fakerjsui.com) - Faker.js UI. Use Faker.js UI to easily generate fake (but realistic) data for testing and development using Faker.js.
 - [Hippocrades](https://hippocrades.com/) - Enterprise-Grade Health Solutions Made Affordable
-
+- [Cudo Compute](https://cudocompute.com/) - Democratized cloud platform built with nuxt3, @nuxt/content and tailwind
+  
 > Please don't hesitate to make a PR if you have more resources to share.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ See a full list on [Vue Telescope](https://www.vuetelescope.com/explore?framewor
 - [Lineup11.net](https://www.lineup11.net/) - Lineup11: Football lineup builder application to help users build football formations and share. Built with Nuxt.js.
 - [Faker.js UI](https://fakerjsui.com) - Faker.js UI. Use Faker.js UI to easily generate fake (but realistic) data for testing and development using Faker.js.
 - [Hippocrades](https://hippocrades.com/) - Enterprise-Grade Health Solutions Made Affordable
-- [Cudo Compute](https://www.cudocompute.com/) - Democratized cloud platform built with nuxt3, @nuxt/content and tailwind
+- [Cudo Compute](https://www.cudocompute.com/) - Democratized cloud platform built with Nuxt 3, @nuxt/content and Tailwind CSS
   
 > Please don't hesitate to make a PR if you have more resources to share.
 


### PR DESCRIPTION
Cudo Compute - Democratised cloud platform built with nuxt3, @nuxt/content and tailwind.

[https://www.cudocompute.com/](https://www.cudocompute.com/)

More info: 

Cudo Compute offers a way to buy cloud infrastructure from data centers around the world. Instead of owning the data center infrastructure, we use existing data centers to provide our service.

The goal is to create a cloud platform that works for traditional data centers (instead of the monopolies) as well as customers looking for cloud infrastructure.