### PR TITLE
Added OpenAI Website in "Projects that uses NuxtJS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ See a full list on [Vue Telescope](https://www.vuetelescope.com/explore?framewor
 - [Hippocrades](https://hippocrades.com/) - Enterprise-Grade Health Solutions Made Affordable
 - [Cudo Compute](https://www.cudocompute.com/) - Democratized cloud platform built with Nuxt 3, @nuxt/content and Tailwind CSS
 - [Pinx](https://themeforest.net/item/pinx-vuejs-admin-template/47799543?ref=DverseStudio&utm_source=awesomevue) - Pinx is an admin template crafted with Vue 3 + TypeScript, developer-friendly and designed with Naive UI and Tailwind CSS. Nuxt compatible! Nuxt Content used on [docs](https://pinx-docs.vercel.app/)
+- [OpenAI Home](https://openai.com) - Creating safe AGI that benefits all of humanity. Built with NuxtJS
   
 > Please don't hesitate to make a PR if you have more resources to share.
 


### PR DESCRIPTION
OpenAI website source code confirms that it uses NuxtJS for their website, I think this could be a good addition in the list of Projects using NuxtJS. 

Added a Snapshot, which confirms the same.
![Screenshot 2023-12-14 at 22 29 29](https://github.com/nuxt/awesome/assets/7466924/69e163ea-5f3c-43db-ade8-f113d163888a)
