### PR TITLE
Added Materio Free Vuetify NuxtJS Admin Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ See a full list on [Vue Telescope](https://www.vuetelescope.com/explore?framewor
 - [Hippocrades](https://hippocrades.com/) - Enterprise-Grade Health Solutions Made Affordable
 - [Cudo Compute](https://www.cudocompute.com/) - Democratized cloud platform built with Nuxt 3, @nuxt/content and Tailwind CSS
 - [Pinx](https://themeforest.net/item/pinx-vuejs-admin-template/47799543?ref=DverseStudio&utm_source=awesomevue) - Pinx is an admin template crafted with Vue 3 + TypeScript, developer-friendly and designed with Naive UI and Tailwind CSS. Nuxt compatible! Nuxt Content used on [docs](https://pinx-docs.vercel.app/)
+- [Materio Free Vuetify NuxtJS Admin Template](https://themeselection.com/item/materio-free-vuetify-nuxtjs-admin-template/) - Open source admin template based on latest Vuetify , NuxtJS 3, Vue 3 & Typescript for developing responsive web apps with ease.
   
 > Please don't hesitate to make a PR if you have more resources to share.
 


### PR DESCRIPTION
An open source & free to use Materio Vuetify NuxtJS Admin Template. 

**Features:**

- Latest NuxtJS 3
- VueJS 3, Vuetify 3
- Vite 5
- Utilizes Vue Router, VueUse
- Available in both TypeScript & JavaScript version
- 1 Dashboard
- Remix Icons
- Basic cards
- Fully Responsive Layout
- Organized Folder Structure
- Clean & Commented Code
- Well Documented