### PR TITLE
Add Craft starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,19 @@ Nuxt's goal is to make web development intuitive and performant, with a great de
 
 ## Contents
 
-- [Official Resources](#official-resources)
-- [Community](#community)
-- [Modules](#modules)
-- [Starter Template](#starter-template)
-- [Official Examples](#official-examples)
-- [Community Examples](#community-examples)
-- [Articles](#articles)
-- [Books](#books)
-- [Open source projects using Nuxt](#open-source-projects-using-nuxt)
-- [Projects Using Nuxt](#projects-using-nuxt)
+- [Awesome Nuxt ](#awesome-nuxt-)
+- [Contents](#contents)
+  - [Official Resources](#official-resources)
+  - [Community](#community)
+  - [Modules](#modules)
+  - [Starter Template](#starter-template)
+  - [Official Examples](#official-examples)
+  - [Community Examples](#community-examples)
+  - [Articles](#articles)
+  - [Books](#books)
+  - [Open source projects using Nuxt](#open-source-projects-using-nuxt)
+  - [Projects Using Nuxt](#projects-using-nuxt)
+- [License](#license)
 
 ### Official Resources
 
@@ -40,6 +43,7 @@ Nuxt's goal is to make web development intuitive and performant, with a great de
 
 ### Starter Template
 
+- [Craft CMS + Nuxt Starter](https://github.com/craftcms/starter-nuxt) - A headless starter integrating Nuxt with Craft CMS, featuring GraphQL support, pagination, and live preview functionality with draft sharing.
 - [Nuxt.new](https://nuxt.new)
 - [nuxt/starter repository](https://github.com/nuxt/starter)
 - [nuxtwind-daisy](https://nuxtwind-daisy.ossph.org) - Nuxtwind Daisy. Nuxtwind Daisy is a starter template project for Nuxt.js 3 + Tailwind CSS + Daisy UI with additional installed setup for custom font, icons, animation, and more.


### PR DESCRIPTION
# Add Craft CMS Nuxt Starter

I'd like to add the official Craft CMS + Nuxt starter project to the Awesome Nuxt list.

This starter provides:
- Integration with Craft CMS's GraphQL API
- Clean separation of frontend and backend code
- Pagination support that matches Craft's native handling
- Live preview functionality with support for shareable draft URLs
- A guestbook example showing GraphQL mutations
- DDEV setup for easy local development

The starter is officially maintained by Pixel & Tonic, the makers of Craft CMS, and serves as a great starting point for developers looking to create headless applications with Nuxt and Craft CMS.
